### PR TITLE
Update JQL search to Jira REST API v3

### DIFF
--- a/rest-calls/jira.rest
+++ b/rest-calls/jira.rest
@@ -17,11 +17,14 @@ GET :url/rest/api/2/issue/:project-2
 #
 
 # Get search of issues
-POST :url/rest/api/2/search
+POST :url/rest/api/3/search/jql
 Content-Type: application/json
 :auth
 {
-  "maxResults": "2"
+  "queries": [
+    {"query": "id = TEST-1"}
+  ],
+  "maxResults": 2
 }
 #
 


### PR DESCRIPTION
## Summary
- use Jira REST v3 JQL search endpoint
- adjust REST call example

## Testing
- `make test` *(fails: emacs: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c3f87c00832ea208a25a496984c7